### PR TITLE
Rerouting to the profile page instead of the home page on login

### DIFF
--- a/client/src/Auth/Auth.js
+++ b/client/src/Auth/Auth.js
@@ -76,8 +76,8 @@ export default class Auth {
     this.idToken = authResult.idToken;
     this.expiresAt = expiresAt;
 
-    // navigate to the home route
-    history.replace('/home');
+    // navigate to the profile route
+    history.replace('/profile');
   }
 
   renewSession() {


### PR DESCRIPTION
A bit irritating that this one line could cause so much grief... But this fixes our current SSO login issues. We were rerouting incorrectly to the /home route in the setState() method, which no longer exists outside of our burn directory. This was confusing Auth0 and by default rerouting it back to our /login route, which reset our user token and confusing Auth0.

This new routing coincides with @JoseaphMankin 's new API routing where we read/write to our backend upon loading the user profile. It makes the most sense to send the user here by default because it will ensure our database is kept in sync on login.

Fixes #49 