### PR TITLE
CallbackUrl now depends on environment

### DIFF
--- a/client/src/Auth/auth0-variables.js
+++ b/client/src/Auth/auth0-variables.js
@@ -1,5 +1,6 @@
 export const AUTH_CONFIG = {
   domain: 'wkruger.auth0.com',
   clientId: 'pPl4zpuRsL0XqcVCtTi1FZcX4yt7O4HF',
-  callbackUrl: 'http://localhost:3000/callback'
+  callbackUrl:   process.env.callbackUrl ||
+  'http://localhost:3000/callback'
 }


### PR DESCRIPTION
While we aren't perfectly securing client id, this should at least allow us to get started testing a later build of heroku. 

Setting the callbackUrl in Auth0 variables to be dependent on environment. We can now set the production environment to use its own base url as opposed to our local machines.