### PR TITLE
Added inProgress and Clock In/Clock Out to session start and end

### DIFF
--- a/client/src/components/EndBtn/EndBtn.js
+++ b/client/src/components/EndBtn/EndBtn.js
@@ -1,17 +1,16 @@
-import React, {Component} from "react";
+import React from "react";
 import "./EndBtn.css";
 import endBtn from "../../images/endBtn.png"
 
 // import { Button } from "react-materialize";
 
 
-class EndBtn extends Component {
-    render(){
+function EndBtn(props) {
         return(
-            <div className="end center" alt="End Session" onClick={this.props.End}>
+            <div className="end center" alt="End Session" onClick={props.onClick}>
                 <img src={endBtn} alt=""/>
             </div>
-        )}}
+        )}
 
 
 export default EndBtn;

--- a/client/src/pages/Drinkory/Drinkory.js
+++ b/client/src/pages/Drinkory/Drinkory.js
@@ -39,7 +39,7 @@ class Drinkory extends Component {
             Drinkory Info
           </div>
           <div className="row">
-            <Link to="/start" className={window.location.pathname === "/start"
+            <Link to="/sessions" className={window.location.pathname === "/sessions"
                 ? "nav-link active" : "nav-link"
             }><SessionBtn />
             </Link>

--- a/client/src/pages/Sessions/Sessions.js
+++ b/client/src/pages/Sessions/Sessions.js
@@ -29,7 +29,8 @@ class Sessions extends Component {
 		maxBAC: 0,
 		tts: "",
         sessionID: "",
-        startTime: ""
+		startTime: "",
+		inProgress: false
 	};
 
 	componentWillMount() {
@@ -42,7 +43,7 @@ class Sessions extends Component {
 				newProfile = profile;
 				this.setState({ profile: newProfile }, () => {
                     let newsub = this.state.profile.sub
-                    let newersub = newsub.substr(newsub.length  - 8)
+                    let newersub = newsub.split('|').pop()
                     this.setState({sub: newersub})
                     API.getUser(newersub).then(res => {
                     if(res.length > 0){
@@ -70,11 +71,11 @@ class Sessions extends Component {
     loadUser = () => {
         
         let newsub = this.state.profile.sub
-        let newersub = newsub.substr(newsub.length - 8)
+        let newersub = newsub.split('|').pop()
         API.getUser(newersub)
             .then(res => {
 
-                console.log("FIND ME" + res);
+                // console.log("FIND ME" + res);
 
                 this.setState({ sex: res.data.sex, weight: res.data.weight, session: []})
 
@@ -208,9 +209,10 @@ class Sessions extends Component {
 		this.setState({ tts: TimeOfSober });
 		console.log(this.state.tts);
 	};
-	End = () => {
+	endSession = () => {
+		console.log("Date punchout" + Date.now())
 		this.setState({ bac: 0, tts: '' });
-		API.saveSession({ maxBAC: this.state.maxBAC, endedAt: Date.now })
+		API.updateSession(this.state.sessionID, { maxBAC: this.state.maxBAC, endedAt: Date.now(), inProgress: false })
 			.then(res => console.log(res))
 			.catch(err => console.log(err));
 	};
@@ -225,7 +227,7 @@ class Sessions extends Component {
 			budget: this.state.budget,
 			sub: this.state.sub,
 		})
-			.then(res => this.setState({ sessionID: res.data._id , startTime: moment()}, () => console.log("TIME: "+ this.state.startTime)))
+			.then(res => this.setState({ sessionID: res.data._id , startTime: moment(), inProgress: res.data.inProgress}, () => console.log("TIME: "+ this.state.startTime)))
             .catch(err => console.log(err));
             
 	};
@@ -262,9 +264,9 @@ class Sessions extends Component {
 					</div>
 					<div className="row">
 						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} onClick={this.addDrink} name="beer" alt="" />
-						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} name="wine" alt="" />
-						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} name="liquor" alt="" />
-						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} name="liquor" alt="" />
+						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} onClick={this.addDrink} name="wine" alt="" />
+						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} onClick={this.addDrink} name="liquor" alt="" />
+						<img src={drinkImg} bac={this.props.bac} onClick={this.takeDrink} onClick={this.addDrink} name="liquor" alt="" />
 					</div>
 					{/* <DrinkContainer>
                 this.state.sessions.drinks.map(drink=>{
@@ -283,10 +285,10 @@ class Sessions extends Component {
 						</Row>
 						<Row>
 							<Link
-								to="/end"
-								className={window.location.pathname === '/end' ? 'nav-link active' : 'nav-link'}
+								to="/drinkory"
+								className={window.location.pathname === '/drinkory' ? 'nav-link active' : 'nav-link'}
 							>
-								<EndBtn End={this.End} />
+								<EndBtn onClick={this.endSession} />
 							</Link>
 						</Row>
 						{/* <EndBtn End={this.End}/> */}

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -38,8 +38,8 @@ export default {
     return axios.post("/api/sessions", sessionData);
   },
   // Updates a session to the database
-  updateUser: function(id, sessionData) {
-    return axios.put("/api/users/" + id, sessionData);
+  updateSession: function(id, sessionData) {
+    return axios.put("/api/sessions/" + id, sessionData);
   },
   // Gets all drinks
   getDrinks: function() {
@@ -58,8 +58,8 @@ export default {
     return axios.post("/api/drinks", drinkData);
   },
   // Updates a drink in the database
-  updateUser: function(id, drinkData) {
-    return axios.put("/api/users/" + id, drinkData);
+  updateDrink: function(id, drinkData) {
+    return axios.put("/api/drinks/" + id, drinkData);
   },
 
 };

--- a/models/session.js
+++ b/models/session.js
@@ -6,7 +6,8 @@ const sessionSchema = new Schema({
   maxBAC: { type: Number, required: false, default: 3 },
   budget: {type: Number, required: false, default: 50 },
   createdAt: { type: Date, default: Date.now },
-  endedAt: { type: Date, default: Date.now },
+  endedAt: { type: Date, required: false },
+  inProgress: {type: Boolean, required: false, default: true},
   drink: [
     {
       // Store ObjectIds in the array

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ app.use(routes);
 
 // // Connect to the Mongo DB
 mongoose.connect(
-  process.env.MONGODB_URI || "mongodb://localhost/NoRegretsDB", { useNewUrlParser: true }
+  process.env.MONGODB_URI || "mongodb://localhost/noRegretsDB", { useNewUrlParser: true }
 );
 
 // Start the API server


### PR DESCRIPTION
fixes #37 

Session model updated to now include an inProgress boolean. This should be able to allow us to spot check first if there's a session that was already running if the app is closed out. (Problem for another issue). 

Also some revisions to the update (axios.put) APIs on Session and Drink

Start and End sessions buttons now include better clockin/clock out managment, and correct session is now recording it's "ended at" correctly when you finish. 